### PR TITLE
#12 認証ロジックをamplifyからsupabaseへ変更

### DIFF
--- a/src/lib/feature/login/presentation/login_screen.dart
+++ b/src/lib/feature/login/presentation/login_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:yamabico/route_type.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final SupabaseClient supabase = Supabase.instance.client;
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  void _signIn() async {
+    try {
+      final response = await supabase.auth.signInWithPassword(
+        email: _emailController.text,
+        password: _passwordController.text,
+      );
+
+      if (response.user != null) {
+        if (!context.mounted) return;
+        Navigator.pushReplacementNamed(context, RouteType.posts().value());
+      }
+    } on AuthException catch (_) {
+      // TODO: ログ
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Error: サインインに失敗しました。'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    } on Exception catch (_) {
+      // TODO: ログ
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Error: サインインに失敗しました。')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('ログイン'),
+        backgroundColor: const Color(0xFF5A606C),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _signIn,
+              child: const Text('Sign In'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/lib/main.dart
+++ b/src/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:yamabico/route_type.dart';
 
 // INFO: ディレクトリ構成参考https://qiita.com/MLLB/items/95617322a7d984b7e402
 
@@ -20,161 +21,17 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final User? user = Supabase.instance.client.auth.currentUser;
+
     return MaterialApp(
-      title: 'Flutter Supabase Example',
+      title: 'Yamabico',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        primarySwatch: Colors.deepOrange,
       ),
-      home: const AuthPage(),
+      routes: RouteType.routeScreenMaps(),
+      initialRoute: (user == null)
+          ? RouteType.guestTop().value()
+          : RouteType.posts().value(),
     );
   }
 }
-
-class MyHomePage extends StatelessWidget {
-  const MyHomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Flutter Supabase Example'),
-      ),
-      body: const Center(
-        child: Text('Welcome to Supabase with Flutter!'),
-      ),
-    );
-  }
-}
-
-class AuthPage extends StatefulWidget {
-  const AuthPage({super.key});
-
-  @override
-  State<AuthPage> createState() => _AuthPageState();
-}
-
-class _AuthPageState extends State<AuthPage> {
-  final SupabaseClient supabase = Supabase.instance.client;
-  final TextEditingController _emailController = TextEditingController();
-  final TextEditingController _passwordController = TextEditingController();
-
-  void _signUp() async {
-    final response = await supabase.auth.signUp(
-      email: _emailController.text,
-      password: _passwordController.text,
-    );
-
-    if (!context.mounted) return;
-    if (response.user == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Error: 登録に失敗しました。')),
-      );
-    } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(
-            'Signed up successfully! Please check your email to confirm.',
-          ),
-        ),
-      );
-    }
-  }
-
-  void _signIn() async {
-    final response = await supabase.auth.signInWithPassword(
-      email: _emailController.text,
-      password: _passwordController.text,
-    );
-
-    if (!context.mounted) return;
-    if (response.user == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Error: サインインに失敗しました。')),
-      );
-    } else {
-      Navigator.of(context).pushReplacement(
-        MaterialPageRoute(builder: (context) => const MyHomePage()),
-      );
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Supabase Auth'),
-      ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Email'),
-            ),
-            TextField(
-              controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
-              obscureText: true,
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _signUp,
-              child: const Text('Sign Up'),
-            ),
-            ElevatedButton(
-              onPressed: _signIn,
-              child: const Text('Sign In'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-
-// class MyApp extends StatefulWidget {
-//   const MyApp({super.key});
-
-//   @override
-//   State<MyApp> createState() => _MyAppState();
-// }
-
-// class _MyAppState extends State<MyApp> {
-//   bool _isAuth = false;
-
-//   @override
-//   void initState() {
-//     super.initState();
-//     _configureAmplify().then(
-//       (value) => {
-//         _isAuthenticated().then((result) => _isAuth = result),
-//       },
-//     );
-//   }
-
-//   Future<void> _configureAmplify() async {
-//     try {
-//       await Amplify.addPlugin(AmplifyAuthCognito());
-//       await Amplify.configure(amplifyconfig);
-//       safePrint('Successfully configured');
-//     } on Exception catch (e) {
-//       safePrint('Error configuring Amplify: $e');
-//     }
-//   }
-
-//   Future<bool> _isAuthenticated() async {
-//     final authState = await Amplify.Auth.fetchAuthSession();
-//     return authState.isSignedIn;
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return MaterialApp(
-//       initialRoute:
-//           _isAuth ? RouteType.posts().value() : RouteType.guestTop().value(),
-//       routes: RouteType.routeScreenMaps(),
-//     );
-//   }
-// }

--- a/src/lib/route_type.dart
+++ b/src/lib/route_type.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:yamabico/feature/login/presentation/login_screen.dart';
 import 'package:yamabico/feature/posts/presentation/index_screen.dart';
 import 'package:yamabico/guest_top_screen.dart';
 import 'package:yamabico/invalid_argument_exception.dart';
-import 'package:yamabico/main.dart';
 
 // REF: https://tech.excite.co.jp/entry/2022/09/12/120000
 
@@ -38,8 +38,8 @@ class RouteType {
 
   static Map<String, Widget Function(BuildContext)> routeScreenMaps() {
     return {
-      _paths['guestTop']!: (context) => const GuestTopScreen(),
-      _paths['login']!: (context) => const AuthPage(),
+      _paths['guestTop']!: (context) => GuestTopScreen(),
+      _paths['login']!: (context) => const LoginScreen(),
       _paths['posts']!: (context) => const IndexScreen(),
       // TODO: userDetailへの遷移を実装する
       // _paths['userDetail']!: (context) => const UserDetailScreen(),


### PR DESCRIPTION
## タスクのリンク
close #12 

## やったこと
- Amplifyで実装していた認証ロジックをSupabaseを使ったものに変更

## やらないこと
- ログアウト処理の実装

## 動作確認
- ログインに成功し、投稿一覧画面へ遷移すること

https://github.com/gizumo-oss/yamabico/assets/26898313/176cca20-c1c0-413a-826d-5e4fd0f6c2f9

## 特にレビューをお願いしたい箇所
- なし

## その他
- なし
