### PR TITLE
Feature/#24

### DIFF
--- a/api/supabase/functions/timeline/index.ts
+++ b/api/supabase/functions/timeline/index.ts
@@ -3,20 +3,23 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 Deno.serve(async (req) => {
   const supaURL: string | undefined = Deno.env.get("SUPABASE_URL")
-  const supaAnonKey: string | undefined = Deno.env.get("SUPABASE_URL")
+  const supaAnonKey: string | undefined = Deno.env.get("SUPABASE_ANON_KEY")
+
   let supabase: any
   if (supaURL !== undefined && supaAnonKey !== undefined) {
     supabase = createClient(supaURL, supaAnonKey)
   }
 
   // user情報を取得
-  // ----------- apiを叩いたuser情報を取得する方法がわからなかった ---------------
-  // const { user, error } = await supabase.auth.refreshSession()
-  // const user = await supabase.auth.getUser()
-  // console.log(user)
-  // urlからクエリパラメータを取得
-  const url = new URL(req.url);
-  const params = new URLSearchParams(url.search);
+  let token = req.headers.get('authorization')
+  if (token != null) {
+    token = token.split('Bearer ')[1];
+  }
+
+  // Requestから情報を取得する
+  const userInfo = await supabase.auth.getUser(token);
+  const url = new URL(req.url)
+  const params = new URLSearchParams(url.search)
   const sortedBy = params.get('sortedBy')
   const orderBy = params.get('orderBy')
   let audios: any
@@ -27,30 +30,17 @@ Deno.serve(async (req) => {
     audios = await supabase
       .from('audios')
       .select('*')
+      .neq('created_by', userInfo.data.user.id)
       .order(sortedBy, {ascending: ascending})
   } else {
     audios = await supabase
       .from('audios')
       .select('*')
+      .neq('created_by', userInfo.data.user.id)
   }
-
-  // ★デバック
-  console.log(audios)
 
   return new Response(
     JSON.stringify(audios),
     { headers: { "Content-Type": "application/json" } },
   )
 })
-
-/* To invoke locally:
-
-  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
-  2. Make an HTTP request:
-
-  curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/timeline' \
-    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
-    --header 'Content-Type: application/json' \
-    --data '{"name":"Functions"}'
-
-*/

--- a/api/supabase/functions/timeline/index.ts
+++ b/api/supabase/functions/timeline/index.ts
@@ -6,15 +6,18 @@ Deno.serve(async (req) => {
   const supaURL: string | undefined = Deno.env.get("SUPABASE_URL")
   const supaAnonKey: string | undefined = Deno.env.get("SUPABASE_ANON_KEY")
   if (supaURL === undefined || supaAnonKey === undefined) {
-    throw new Error('環境変数を設定してください。');
+    return new Response(
+      JSON.stringify('環境変数を設定してください'),
+      {
+        headers: { "Content-Type": "application/json" },
+        status: 401
+      },
+    )
   }
   const supabase = createClient(supaURL, supaAnonKey)
 
   // user情報を取得
   let token = req.headers.get('authorization')
-  if (token === null) {
-    throw new Error('unauthorized');
-  }
   const userInfo = await supabase.auth.getUser(token.slice(7));
 
   // エンドポイントから情報の抜き出し

--- a/api/supabase/functions/timeline/index.ts
+++ b/api/supabase/functions/timeline/index.ts
@@ -15,7 +15,7 @@ Deno.serve(async (req) => {
   if (token === null) {
     throw new Error('unauthorized');
   }
-  const userInfo = await supabase.auth.getUser(token.split('Bearer ')[1]);
+  const userInfo = await supabase.auth.getUser(token.slice(7));
 
   // エンドポイントから情報の抜き出し
   const url = new URL(req.url)

--- a/api/supabase/functions/timeline/index.ts
+++ b/api/supabase/functions/timeline/index.ts
@@ -1,0 +1,56 @@
+import "https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+Deno.serve(async (req) => {
+  const supaURL: string | undefined = Deno.env.get("SUPABASE_URL")
+  const supaAnonKey: string | undefined = Deno.env.get("SUPABASE_URL")
+  let supabase: any
+  if (supaURL !== undefined && supaAnonKey !== undefined) {
+    supabase = createClient(supaURL, supaAnonKey)
+  }
+
+  // user情報を取得
+  // ----------- apiを叩いたuser情報を取得する方法がわからなかった ---------------
+  // const { user, error } = await supabase.auth.refreshSession()
+  // const user = await supabase.auth.getUser()
+  // console.log(user)
+  // urlからクエリパラメータを取得
+  const url = new URL(req.url);
+  const params = new URLSearchParams(url.search);
+  const sortedBy = params.get('sortedBy')
+  const orderBy = params.get('orderBy')
+  let audios: any
+
+  if (sortedBy !== null) {
+    const ascending = orderBy !== 'asc' ? true : false
+
+    audios = await supabase
+      .from('audios')
+      .select('*')
+      .order(sortedBy, {ascending: ascending})
+  } else {
+    audios = await supabase
+      .from('audios')
+      .select('*')
+  }
+
+  // ★デバック
+  console.log(audios)
+
+  return new Response(
+    JSON.stringify(audios),
+    { headers: { "Content-Type": "application/json" } },
+  )
+})
+
+/* To invoke locally:
+
+  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
+  2. Make an HTTP request:
+
+  curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/timeline' \
+    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
+    --header 'Content-Type: application/json' \
+    --data '{"name":"Functions"}'
+
+*/

--- a/api/supabase/functions/timeline/index.ts
+++ b/api/supabase/functions/timeline/index.ts
@@ -15,8 +15,6 @@ Deno.serve(async (req) => {
   if (token != null) {
     token = token.split('Bearer ')[1];
   }
-
-  // Requestから情報を取得する
   const userInfo = await supabase.auth.getUser(token);
   const url = new URL(req.url)
   const params = new URLSearchParams(url.search)
@@ -24,6 +22,7 @@ Deno.serve(async (req) => {
   const orderBy = params.get('orderBy')
   let audios: any
 
+  // ソート
   if (sortedBy !== null) {
     const ascending = orderBy !== 'asc' ? true : false
 

--- a/api/supabase/functions/timeline/index.ts
+++ b/api/supabase/functions/timeline/index.ts
@@ -3,8 +3,8 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
 Deno.serve(async (req) => {
   // supabaseクライアント作成
-  const supaURL: string | undefined = Deno.env.get("SUPABASE_URL")
-  const supaAnonKey: string | undefined = Deno.env.get("SUPABASE_ANON_KEY")
+  const supaURL: string | undefined = Deno.env.get("SUPABASE_URL");
+  const supaAnonKey: string | undefined = Deno.env.get("SUPABASE_ANON_KEY");
   if (supaURL === undefined || supaAnonKey === undefined) {
     return new Response(
       JSON.stringify('環境変数を設定してください'),
@@ -12,18 +12,18 @@ Deno.serve(async (req) => {
         headers: { "Content-Type": "application/json" },
         status: 401
       },
-    )
+    );
   }
-  const supabase = createClient(supaURL, supaAnonKey)
+  const supabase = createClient(supaURL, supaAnonKey);
 
   // user情報を取得
-  let token = req.headers.get('authorization')
+  let token = req.headers.get('authorization');
   const userInfo = await supabase.auth.getUser(token.slice(7));
 
   // エンドポイントから情報の抜き出し
-  const url = new URL(req.url)
-  const params = new URLSearchParams(url.search)
-  const sortedBy = params.get('sortedBy')
+  const url = new URL(req.url);
+  const params = new URLSearchParams(url.search);
+  const sortedBy = params.get('sortedBy');
 
   // DBへのリクエスト
   const query = supabase
@@ -39,5 +39,5 @@ Deno.serve(async (req) => {
   return new Response(
     JSON.stringify(await query),
     { headers: { "Content-Type": "application/json" } },
-  )
-})
+  );
+});


### PR DESCRIPTION
## タスクのリンク
- https://github.com/gizumo-oss/yamabico/issues/24

## やったこと
- ログインユーザーを特定する
- 他人のaudio情報を返す(creation_byのuuidと比較して)
- ソートの処理

## やらないこと
- 

## 動作確認
- Talend API Testerを用いてエンドポイントを叩いて、他人のaudio情報のみが帰ってくることを確認
- 流れ
    - bunx supabase start
    - bunx supabase functions serve
    - ログインのapiを叩く
![image](https://github.com/user-attachments/assets/8b8e3d5e-6b22-4d17-b2f4-5697e6ecdb54)
    - 上記画像のaccess_tokenをヘッダーのAuthorizationにBearerをつけてエンドポイントを叩く
![image](https://github.com/user-attachments/assets/5c0e5aed-43fe-4dd9-957b-01b1d74c7edc)



## 特にレビューをお願いしたい箇所
- 要件に沿った実装になっているか
- ソートのやり方が変かもなので見て欲しい

## その他
- supabaseクライアントを作成するのがどのapiでも同じ仕組みになりそうです